### PR TITLE
Make plugin work with api v8.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,62 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+  schedule:
+    - cron: '0 1 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Override automatic language detection by changing the below list
+        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
+        language: ['javascript']
+        # Learn more...
+        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/facebook/galleria.facebook.js
+++ b/facebook/galleria.facebook.js
@@ -15,10 +15,9 @@ Galleria.requires(1.25, 'The Facebook Plugin requires Galleria version 1.2.5 or 
 
 // The script path
 var PATH = Galleria.utils.getScriptPath();
-
 // The version of the Facebook API that we are currently supporting
 // used to version the API request like https://graph.facebook.com/v2.3/REQUEST
-var FACEBOOK_API_VERSION = 'v2.3'
+var FACEBOOK_API_VERSION = 'v8.0'
 
 /**
 
@@ -93,7 +92,7 @@ Galleria.Facebook.prototype = {
 	// https://developers.facebook.com/docs/graph-api/using-graph-api/v2.3
 	// Thank you @wundo for the initial fix: https://github.com/aiaio/galleria-facebook/compare/master...wundo:whitespace
 	// Thank you @randomdave and @norbertFeron for your help diagnosing and solving: https://github.com/aiaio/galleria-facebook/issues/14
-	var url = 'https://graph.facebook.com/' + FACEBOOK_API_VERSION + '/' + params['album_id'] + '?callback=?' + '&fields=photos.limit(' + this.options.max + '){images,source,picture,link,name}&access_token=' + this.options.facebook_access_token
+	var url = 'https://graph.facebook.com/' + FACEBOOK_API_VERSION + '/' + params['album_id'] + '?callback=?' + '&fields=photos.limit(' + this.options.max + '){images,picture,link,name}&access_token=' + this.options.facebook_access_token;
 
         var scope = this;
 
@@ -136,11 +135,11 @@ Galleria.Facebook.prototype = {
                 break;
 
             case 'original':
-                img = photo.source;
+                img = this._getBig( photo );
                 break;
 
             default:
-                img = photo.source;
+                img = this._getBig( photo );
                 break;
         }
         return img;


### PR DESCRIPTION
Source field is obsoleted and is replaced by images[].source to be selected. So we drop the original source in replacement for the big image (although we could take smaller one.

Closes #22 

Sidenote: I am not really in favor of committing towards unlicensed repository, but I assume since you put it on GitHub, that you would accept contributions. I am acting in spirit of the community and if you want, I can also open a PR with some GPL license to get us running? This pull request is provided with MIT license, just so that you can do whatever you like :wink: 